### PR TITLE
test: add tests for single file

### DIFF
--- a/e2e/__snapshots__/e2e.test.ts.snap
+++ b/e2e/__snapshots__/e2e.test.ts.snap
@@ -25,6 +25,8 @@ Created 'build/a/b/The Adventure of the Six Napoleans.html'
 Created 'build/c/The Adventure of the Speckled Band.html'"
 `;
 
+exports[`end to end test use input option on a file 1`] = `"Created 'build/The Naval Treaty.html'"`;
+
 exports[`end to end test use invalid css file 1`] = `"'src/index.ts' is not a css file"`;
 
 exports[`end to end test use invalid language  1`] = `"Unsupported HTML language"`;
@@ -37,6 +39,8 @@ Created 'build/The Adventure of the Speckled Band.html'
 Created 'build/The Naval Treaty.html'
 Created 'build/The Red Headed League.html'"
 `;
+
+exports[`end to end test use recursive option on a file 1`] = `"Created 'build/The Naval Treaty.html'"`;
 
 exports[`end to end test use relative option 1`] = `
 "Created 'build/The Naval Treaty.html'

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -68,4 +68,18 @@ describe('end to end test', () => {
     expect(exitCode).toEqual(1);
     expect(stdout).toEqual('');
   });
+
+  test('use input option on a file', async () => {
+    const { stderr, stdout, exitCode } = await run('-i assets/text/The\\ Naval\\ Treaty.txt');
+    expect(stderr).toEqual('');
+    expect(exitCode).toEqual(0);
+    expect(sortConsoleLogs(stdout)).toMatchSnapshot();
+  });
+
+  test('use recursive option on a file', async () => {
+    const { stderr, stdout, exitCode } = await run('-i assets/text/The\\ Naval\\ Treaty.txt -r');
+    expect(stderr).toEqual('');
+    expect(exitCode).toEqual(0);
+    expect(sortConsoleLogs(stdout)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Closes #16 

Need to add a SilverBlaze.txt file and update previous snapshots because there is a parsing error with `execa`. Here's how a file name with spaces is parsed (log from `argv()` ).

![image](https://user-images.githubusercontent.com/52666982/142356728-c311efbf-3d0c-447c-829d-f010de73192f.png)

Things I have tried but didn't work
```
 const { stderr, stdout, exitCode } = await run('-i assets/text/The\ Naval\ Treaty.txt');

 const { stderr, stdout, exitCode } = await run('-i "assets/text/The Naval Treaty.txt"');

 const { stderr, stdout, exitCode } = await run('-i \'assets/text/The Naval Treaty.txt\'');

 const { stderr, stdout, exitCode } = await run('-i assets/text/\'The Naval Treaty.txt\'');